### PR TITLE
Fix documentation URL to use custom domain

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -15,7 +15,7 @@ const config: Config = {
   },
 
   // Set the production url of your site here
-  url: 'https://griswaldbrooks.github.io',
+  url: 'https://griswaldbrooks.com',
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
   baseUrl: '/spanny3/',


### PR DESCRIPTION
Change Docusaurus URL from griswaldbrooks.github.io to griswaldbrooks.com to match the custom domain configured for GitHub Pages.

This fixes the documentation deployment issue where GitHub redirects griswaldbrooks.github.io/spanny3/ to griswaldbrooks.com/spanny3/, causing the site to appear broken because Docusaurus was generating URLs for the wrong domain.

The issue occurs because the main griswaldbrooks.github.io site uses a custom domain (griswaldbrooks.com), which causes GitHub Pages to redirect ALL subpaths (including /spanny3/) to the custom domain.

After this change, documentation will be accessible at: https://griswaldbrooks.com/spanny3/

Changes:
- Updated docs/docusaurus.config.ts url field to use custom domain
- Kept baseUrl as /spanny3/ (unchanged)
- Build verified successful locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)